### PR TITLE
FIXES: Forks option ignored in cli 

### DIFF
--- a/bin/overseer
+++ b/bin/overseer
@@ -63,6 +63,7 @@ if (!fs.existsSync(appFile)) {
 
 // Setup overseer and run
 require('../src/overseer')(appFile, {
+    forks: program.forks,
     env: program.env,
     pidfile: program.pidfile,
     watch: program.watch || false


### PR DESCRIPTION
When running overseer from the cli, the forks option was not being passed through, resulting in always one worker being spawned.
